### PR TITLE
Bugfix

### DIFF
--- a/src/Ovh/Sms/SmsClient.php
+++ b/src/Ovh/Sms/SmsClient.php
@@ -311,6 +311,8 @@ class smsClient extends AbstractClient
             $opt['class'] = intval($opt['class']);
             if ($opt['class'] < 0 || $opt['class'] > 3)
                 $job['class'] = 2;
+						else
+								$job['class'] = $opt['class'];
         } else $job['class'] = 2;
 
         unset($opt); // not - really - usefull...


### PR DESCRIPTION
Using the SDK to send SMS via a website, I had errors in the OVH Manager.
The problem was that the $job['class'] is never setted when the provided value is correct.
