### PR TITLE
Add the new way to restore or delete public cloud archive sessions

### DIFF
--- a/src/Ovh/Cloud/CloudClient.php
+++ b/src/Ovh/Cloud/CloudClient.php
@@ -256,42 +256,48 @@ class CloudClient extends AbstractClient
         return $r->getBody(true);
     }
 
-
     /**
      * @param string $pp OVH cloud passport
      * @param string $pca PCA service name
-     * @param string $task task to add
-     * @return string json encoded array)
+     * @param string $sessionId session id to delete
+     * @return string json encoded array
      * @throws \Ovh\Cloud\Exception\CloudException
      * @throws \Ovh\Common\Exception\BadMethodCallException
      */
-    public function addPcaTaskProperties($pp, $pca, $task)
+    public function createPcaDeleteTask($pp, $pca, $sessionId)
     {
         if (!$pp)
             throw new BadMethodCallException('Missing parameter $pp (OVH cloud passport).');
         if (!$pca)
             throw new BadMethodCallException('Missing parameter $pca (PCA ServiceName).');
-        if (!$task)
-            throw new BadMethodCallException('Missing parameter $task (array task to add).');
-        if (!is_array($task))
-            throw new BadMethodCallException('Parameter $task must be an array.');
-        // clean array
-        $requiredKeys = array('sessionId', 'taskFunction', 'fileIds');
-        foreach ($task as $k => $v) {
-            if (!in_array($k, $requiredKeys)) {
-                unset($task[$k]);
-            }
-        }
-        if (count($task) != 3)
-            throw new BadMethodCallException("Parameter $task must be a array 'sessionId', 'taskFunction', 'fileIds'");
-        // taskFunction ?
-        if (!in_array($task['taskFunction'], array('restore', 'delete')))
-            throw new BadMethodCallException('Parameter $task[\'taskFunction\'] must be "restore" or "delete". ' . $task['taskFunction'] . ' given.');
-        // fileIds
-        if (!is_array($task['fileIds']))
-            throw new BadMethodCallException('Parameter $task[\'fileIds\'] must a array of fileId. ' . gettype($task['taskFunction']) . ' given.');
+        if (!$sessionId)
+             throw new BadMethodCallException('Missing parameter $sessionId (string).');
         try {
-            $r = $this->post('cloud/' . $pp . '/pca/' . $pca . '/tasks', array('Content-Type' => 'application/json;charset=UTF-8'), json_encode($task))->send();
+            $r = $this->delete('cloud/' . $pp . '/pca/' . $pca . '/sessions/' . $sessionId)->send();
+        } catch (\Exception $e) {
+            throw new CloudException($e->getMessage(), $e->getCode(), $e);
+        }
+        return $r->getBody(true);
+    }
+
+    /**
+     * @param string $pp OVH cloud passport
+     * @param string $pca PCA service name
+     * @param string $sessionId session id to restore
+     * @return string json encoded array
+     * @throws \Ovh\Cloud\Exception\CloudException
+     * @throws \Ovh\Common\Exception\BadMethodCallException
+     */
+    public function createPcaRestoreTask($pp, $pca, $sessionId)
+    {
+        if (!$pp)
+            throw new BadMethodCallException('Missing parameter $pp (OVH cloud passport).');
+        if (!$pca)
+            throw new BadMethodCallException('Missing parameter $pca (PCA ServiceName).');
+        if (!$sessionId)
+             throw new BadMethodCallException('Missing parameter $sessionId (string).');
+        try {
+            $r = $this->post('cloud/' . $pp . '/pca/' . $pca . '/sessions/' . $sessionId . '/restore')->send();
         } catch (\Exception $e) {
             throw new CloudException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Ovh/Cloud/Pca.php
+++ b/src/Ovh/Cloud/Pca.php
@@ -186,9 +186,44 @@ class Pca
      *
      * @param  array $task. Keys : string sessionId, string taskFunction (restore|delete), array of string fileIds.
      * @return object task
+     * @throws \Ovh\Common\Exception\BadMethodCallException
+     * @deprecated Use addDeleteTask or addRestoreTask
      */
-    public function addTask($task){
-        return json_decode(self::getClient()->addPcaTaskProperties($this->pp, $this->sn,$task));
+    public function addTask(array $task)
+    {
+        if (!array_key_exists('sessionId', $task))
+            throw new BadMethodCallException("Parameter $task must have the key 'sessionId'");
+        if (!array_key_exists('taskFunction', $task))
+            throw new BadMethodCallException("Parameter $task must have the key 'taskFunction'");
+
+        if ($task['taskFunction'] == 'restore') {
+            return json_decode(self::getClient()->createPcaRestoreTask($this->pp, $this->sn,$task['sessionId']));
+        } elseif ($task['taskFunction'] == 'delete') {
+            return json_decode(self::getClient()->createPcaDeleteTask($this->pp, $this->sn,$task['sessionId']));
+        }
+        throw new BadMethodCallException("Task function available are 'delete' or 'restore'");   
+    }
+
+    /**
+     * Add a new delete task
+     * 
+     * @param string $sessionId The session id to delete.
+     * @param object task
+     */
+    public function addDeleteTask($sessionId)
+    {
+        return json_decode(self::getClient()->createPcaDeleteTask($this->pp, $this->sn, $sessionId));
+    }
+
+    /**
+     * Add a new restore task
+     * 
+     * @param string $sessionId The session id to restore.
+     * @param object task
+     */
+    public function addRestoreTask($sessionId)
+    {
+        return json_decode(self::getClient()->createPcaRestoreTask($this->pp, $this->sn, $sessionId));
     }
 
     /**

--- a/tests/tests/PcaTest.php
+++ b/tests/tests/PcaTest.php
@@ -194,6 +194,42 @@ class PcaTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * We will test delete task
+     *
+     * @depends testGetSessions
+     */
+    public function testDeleteSession($session)
+    {
+        if($session) {
+            $t = $this->pca->addDeleteTask($session);
+            $this->assertTrue(is_object($t), "Returned value must be an object");
+            $this->assertCount(7, (array)$t, "Returned object must have 7 attributes");
+            foreach (array('function', 'comment', 'status', 'todoDate', 'ipAddress', 'id', 'login') as $attr) {
+                $this->assertObjectHasAttribute($attr, $t, "PCA task must have attribute '$attr'");
+            }
+            $this->assertTrue($t->status=='todo');
+        }
+    }
+
+    /**
+     * We will test restore task
+     *
+     * @depends testGetSessions
+     */
+    public function testRestoreSession($session)
+    {
+        if($session) {
+            $t = $this->pca->addRestoreTask($session);
+            $this->assertTrue(is_object($t), "Returned value must be an object");
+            $this->assertCount(7, (array)$t, "Returned object must have 7 attributes");
+            foreach (array('function', 'comment', 'status', 'todoDate', 'ipAddress', 'id', 'login') as $attr) {
+                $this->assertObjectHasAttribute($attr, $t, "PCA task must have attribute '$attr'");
+            }
+            $this->assertTrue($t->status=='todo');
+        }
+    }
+
     public function testGetUsage(){
         $u=$this->pca->getUsage();
         $this->assertTrue(is_int($u));


### PR DESCRIPTION
The OVH api has changed for delete or restore an session in the public cloud archive. 

```
POST /cloud/{serviceName}/pca/{pcaServiceName}/tasks 
```

is replaced by 

```
DELETE /cloud/{serviceName}/pca/{pcaServiceName}/sessions/{sessionId} 
```

[source for delete](https://api.ovh.com/console/#/cloud/%7BserviceName%7D/pca/%7BpcaServiceName%7D/sessions/%7BsessionId%7D#DELETE)

```
POST /cloud/{serviceName}/pca/{pcaServiceName}/sessions/{sessionId}/restore
```

[source for restore](https://api.ovh.com/console/#/cloud/%7BserviceName%7D/pca/%7BpcaServiceName%7D/sessions/%7BsessionId%7D/restore#POST)
