### PR TITLE
Choix de l'URL de l'API

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,15 @@ require_once 'vendor/autoload.php';
 use \Ovh\Common\Ovh;
 
 // Populate your keyring
+/** RG : APPLICATION REGION
+* 'FR' => 'https://api.ovh.com/1.0/'
+* 'CA' => 'https://ca.api.ovh.com/1.0/'
+*/
 $config=array(
     'AK' => 'YOUR APPLICATION KEY',
     'AS' => 'YOUR APPLICATION SECRET',
-    'CK' => 'YOUR CONSUMER KEY'
+    'CK' => 'YOUR CONSUMER KEY',
+    'RG' => 'YOUR APPLICATION REGION' 
 );
 
 // Init your OVH instance

--- a/src/Ovh/Common/AbstractClient.php
+++ b/src/Ovh/Common/AbstractClient.php
@@ -2,6 +2,11 @@
 /**
  * Copyright 2013 Stéphane Depierrepont (aka Toorop)
  *
+ * Authors :
+ *  - Stéphane Depierrepont (aka Toorop)
+ *  - Florian Jensen (aka flosoft) : https://github.com/flosoft
+ *  - Gillardeau Thibaut (aka Thibautg16) 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
@@ -32,7 +37,7 @@ class AbstractClient extends Client
 
     public function __construct()
     {
-        parent::__construct('https://api.ovh.com/1.0/');
+        parent::__construct(Keyring::getAppUrlRegion());
     }
 
 

--- a/src/Ovh/Common/Auth/Keyring.php
+++ b/src/Ovh/Common/Auth/Keyring.php
@@ -2,6 +2,11 @@
 /**
  * Copyright 2013 Stéphane Depierrepont (aka Toorop)
  *
+ * Authors :
+ *  - Stéphane Depierrepont (aka Toorop)
+ *  - Florian Jensen (aka flosoft) : https://github.com/flosoft
+ *  - Gillardeau Thibaut (aka Thibautg16) 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
@@ -31,6 +36,8 @@ class Keyring
     static private $appKey = null;
     static private $appSecret = null;
     static private $consumerKey = null;
+    //Le paramètre "appUrlRegion" permet de choisir avec quelle API on veut travailler (FR ou CA)
+    static private $appUrlRegion = null;
 
 
     public static function setAppKey($key)
@@ -63,4 +70,24 @@ class Keyring
         return self::$consumerKey;
     }
 
+    /** Paramètre "UrlRegion"  
+    * FR = api.ovh.com
+    * CA = ca.api.ovh.com
+    */
+    public static function setAppUrlRegion($Region){
+		self::$appUrlRegion = self::getUrlApi($Region);
+	}
+	
+	public static function getAppUrlRegion(){
+		return self::$appUrlRegion;
+	}
+
+	public static function getUrlApi($Region){
+		if($Region == 'FR'){
+			return 'https://api.ovh.com/1.0/';
+		}
+		elseif($Region == 'CA'){
+			return 'https://ca.api.ovh.com/1.0/';    
+		}
+	}
 }

--- a/src/Ovh/Common/Ovh.php
+++ b/src/Ovh/Common/Ovh.php
@@ -5,6 +5,7 @@
  * Authors :
  *  - Stéphane Depierrepont (aka Toorop)
  *  - Florian Jensen (aka flosoft) : https://github.com/flosoft
+ *  - Gillardeau Thibaut (aka Thibautg16) 
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -53,6 +54,8 @@ class Ovh
         Keyring::setAppKey($config['AK']);
         Keyring::setAppSecret($config['AS']);
         Keyring::setConsumerKey($config['CK']);
+	keyring::setAppUrlRegion($config['RG']);
+
     }
 
 


### PR DESCRIPTION
Implantation du choix de l'API utilisé (FR ou CA) :
/*\* RG : APPLICATION REGION
- 'FR' => 'https://api.ovh.com/1.0/'
- 'CA' => 'https://ca.api.ovh.com/1.0/'
  */

https://github.com/Toorop/ovh-sdk-php/issues/25
